### PR TITLE
Add missing imports to Laravel example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,10 @@ For example, in Laravel you could do something like this:
 ```php
 namespace App\Providers;
  
-use App\Environment;
 use Crell\Config\ConfigLoader;
 use Crell\Config\LayeredLoader;
 use Crell\Config\PhpFileSource;
 use Crell\Config\SerializedFilesystemCache;
-use Crell\EnvMapper\EnvMapper;
 use Crell\Serde\Serde;
 use Crell\Serde\SerdeCommon;
 use Illuminate\Contracts\Foundation\Application;

--- a/README.md
+++ b/README.md
@@ -167,7 +167,13 @@ For example, in Laravel you could do something like this:
 namespace App\Providers;
  
 use App\Environment;
+use Crell\Config\ConfigLoader;
+use Crell\Config\LayeredLoader;
+use Crell\Config\PhpFileSource;
+use Crell\Config\SerializedFilesystemCache;
 use Crell\EnvMapper\EnvMapper;
+use Crell\Serde\Serde;
+use Crell\Serde\SerdeCommon;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
  


### PR DESCRIPTION
Feel free to take this change or leave it, but a personal pet peeve of mine is code examples that make me hunt down FQCNs to make them work.