### PR TITLE
Suggest missing "symfony/yaml" dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can and should define as many different config objects as you'd like.  They 
 ## Source types
 
 There are several file formats supported out of the box, including `JsonFileSource`, `YamlFileSource`, `PhpFileSource`, and even `IniFileSource` (because why not?).  
-Note: In order to use the `YamlFileSource` you need to have the [`symfony/yaml`](https://packagist.org/packages/symfony/yaml) installed. 
+Note: In order to use the `YamlFileSource` you need to have the [`symfony/yaml`](https://packagist.org/packages/symfony/yaml) package installed. 
 
 Writing other sources is simple, as the `ConfigSource`interface has only a single method.  
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ You can and should define as many different config objects as you'd like.  They 
 
 ## Source types
 
-There are several file formats supported out of the box, including `JsonFileSource`, `YamlFileSource`, `PhpFileSource`, and even `IniFileSource` (because why not?).  Writing other sources is simple, as the `ConfigSource`interface has only a single method.  You can even stack multiple file types with the same directory to read from into a single list, if you want to support multiple file types.
+There are several file formats supported out of the box, including `JsonFileSource`, `YamlFileSource`, `PhpFileSource`, and even `IniFileSource` (because why not?).  
+Note: In order to use the `YamlFileSource` you need to have the [`symfony/yaml`](https://packagist.org/packages/symfony/yaml) installed. 
+
+Writing other sources is simple, as the `ConfigSource`interface has only a single method.  
+
+You can even stack multiple file types with the same directory to read from into a single list, if you want to support multiple file types.
 
 ## Custom file keys
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "psr/cache": "^3.0",
         "fig/cache-util": "^2.0"
     },
+    "suggest": {
+        "symfony/yaml": "Required to use the YAML source type"
+    },
     "autoload": {
         "psr-4": {
             "Crell\\Config\\": "src"

--- a/tests/ConfigObjects/Dashboard/Dashboard.php
+++ b/tests/ConfigObjects/Dashboard/Dashboard.php
@@ -13,6 +13,9 @@ use Crell\Serde\KeyType;
 #[Config('dashboard')]
 class Dashboard
 {
+    /**
+     * @param array<string, LatestPosts|UserStatus|PostsNeedModeration> $components
+     */
     public function __construct(
         public string $name,
         #[Field(flatten: true)]


### PR DESCRIPTION
To use the YAML source type, the `symfony/yaml` package is required.