### PR TITLE
PHPStan Fixes

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     phpstan:
-        name: PHPUnit tests on ${{ matrix.php }} ${{ matrix.composer-flags }}
+        name: PHPStan tests on ${{ matrix.php }} ${{ matrix.composer-flags }}
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.3",
         "phpbench/phpbench": "^1.1",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.11",
         "vishnubob/wait-for-it": "dev-master",
         "mikey179/vfsstream": "^1.6",
         "symfony/yaml": "^6.2",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
     checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
         -
-            message: '#type has no value type specified in iterable type array#'
+            identifier: missingType.iterableValue
             path: tests/
 #        -
 #            message: '#type has no value type specified in iterable type iterable#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,11 +9,11 @@ parameters:
         -
             identifier: missingType.iterableValue
             path: tests/
-#        -
-#            message: '#type has no value type specified in iterable type iterable#'
-#            path: tests/
+        -
+            message: '#type has no value type specified in iterable type iterable#'
+            path: tests/
         # PHPStan is overly aggressive on readonly properties.
-#        - '#Class (.*) has an uninitialized readonly property (.*). Assign it in the constructor.#'
-#        - '#Readonly property (.*) is assigned outside of the constructor.#'
+        - '#Class (.*) has an uninitialized readonly property (.*). Assign it in the constructor.#'
+        - '#Readonly property (.*) is assigned outside of the constructor.#'
         # getName() is defined on ReflectionType, but Reflection's interfaces are buggy.
-#        - '#Call to an undefined method ReflectionType::getName\(\).#'
+        - '#Call to an undefined method ReflectionType::getName\(\).#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,9 @@ parameters:
     paths:
         - src
         - tests
-    checkGenericClassInNonGenericObjectType: false
+    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
+        - identifier: missingType.generics
         -
             identifier: missingType.iterableValue
             path: tests/

--- a/tests/ConfigObjects/Dashboard/Dashboard.php
+++ b/tests/ConfigObjects/Dashboard/Dashboard.php
@@ -13,6 +13,9 @@ use Crell\Serde\KeyType;
 #[Config('dashboard')]
 class Dashboard
 {
+    /**
+     * @param array<string, LatestPosts|UserStatus|PostsNeedModeration> $components
+     */
     public function __construct(
         public string $name,
         #[Field(flatten: true)]


### PR DESCRIPTION
This pull requests addresses some "issues" with PHPStan.

1. Fixes a typo in the GitHub workflow job name
2. Removes a deprecated config option, that is not necessary (no errors without it)
3. Removes commented out "ignoreErrors" options
4. Adds PHPDoc to describe array parameters and return values
5. Removes now obsolete "ignoreError" option to ignore missing array shape declarations